### PR TITLE
Add support for unique index in pstress

### DIFF
--- a/src/common.hpp
+++ b/src/common.hpp
@@ -55,6 +55,7 @@ struct Option {
     NO_VIRTUAL_COLUMNS,
     TABLES,
     INDEXES,
+    UNIQUE_INDEX_PROB_K,
     ALGORITHM,
     LOCK,
     COLUMNS,

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -220,6 +220,13 @@ void add_options() {
   opt->setBool(false);
   opt->setArgs(no_argument);
 
+  /* unique index probability out of thousand */
+  opt =
+      newOption(Option::INT, Option::UNIQUE_INDEX_PROB_K, "unique-key-prob-k");
+  opt->help = "probability of creating unique index on table out of 1000. "
+              "Currently only supported if a table have int column";
+  opt->setInt(1);
+
   /* Only Partition tables */
   opt =
       newOption(Option::BOOL, Option::ONLY_PARTITION, "only-partition-tables");

--- a/src/random_test.hpp
+++ b/src/random_test.hpp
@@ -17,6 +17,7 @@
 #include <random>
 #include <sstream>
 #include <string.h>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 #include <writer.h>
@@ -135,7 +136,7 @@ struct Ind_col {
 };
 
 struct Index {
-  Index(std::string n);
+  Index(std::string n, bool u = false);
   void AddInternalColumn(Ind_col *column);
   template <typename Writer> void Serialize(Writer &writer) const;
   ~Index();
@@ -144,6 +145,7 @@ struct Index {
 
   std::string name_;
   std::vector<Ind_col *> *columns_;
+  bool unique;
 };
 
 struct Thd1 {


### PR DESCRIPTION
https://github.com/rahulmalik87/pstress/issues/21

Add support for unique keys in Pstress, It would help to encounter any issue due to violation of unique key in a cluster environment.

Currently only supported if a index have int column.

Added option --unique-key-prob-k out of 1000